### PR TITLE
[BUGFIX] Convert level to int in log writer

### DIFF
--- a/Classes/Log/Writer/SysLogDatabaseWriter.php
+++ b/Classes/Log/Writer/SysLogDatabaseWriter.php
@@ -5,6 +5,7 @@ namespace EMAILOBFUSCATOR\Emailobfuscator\Log\Writer;
 
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Log\LogLevel;
 use TYPO3\CMS\Core\Log\LogRecord;
 use TYPO3\CMS\Core\Log\Writer\DatabaseWriter;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -34,7 +35,7 @@ class SysLogDatabaseWriter extends DatabaseWriter
             'request_id' => $record->getRequestId(),
             'time_micro' => $record->getCreated(),
             'component' => $record->getComponent(),
-            'level' => $record->getLevel(),
+            'level' => LogLevel::normalizeLevel($record->getLevel()),
             'message' => $record->getMessage(),
             'data' => $data,
 //            'userid' => 1,


### PR DESCRIPTION
Database field sys_log.level is of type int. Writing string may cause problems
with strict type checking.

Resolves: #5